### PR TITLE
Revert "Unit Test: Parsing "2e308" in full precision generates NAN value and kParseErrorNone"

### DIFF
--- a/test/unittest/readertest.cpp
+++ b/test/unittest/readertest.cpp
@@ -192,7 +192,6 @@ static void TestParseDouble() {
         ParseDoubleHandler h; \
         Reader reader; \
         ASSERT_EQ(kParseErrorNone, reader.Parse<fullPrecision ? kParseFullPrecisionFlag : 0>(s, h).Code()); \
-        EXPECT_EQ(h.actual_, h.actual_); /* detect generation of NAN */ \
         EXPECT_EQ(1u, h.step_); \
         internal::Double e(x), a(h.actual_); \
         if (fullPrecision) { \
@@ -226,7 +225,6 @@ static void TestParseDouble() {
     TEST_DOUBLE(fullPrecision, "1.234E-10", 1.234E-10);
     TEST_DOUBLE(fullPrecision, "1.79769e+308", 1.79769e+308);
     TEST_DOUBLE(fullPrecision, "2.22507e-308", 2.22507e-308);
-    TEST_DOUBLE(fullPrecision, "2e308", std::numeric_limits<double>::infinity());
     TEST_DOUBLE(fullPrecision, "-1.79769e+308", -1.79769e+308);
     TEST_DOUBLE(fullPrecision, "-2.22507e-308", -2.22507e-308);
     TEST_DOUBLE(fullPrecision, "4.9406564584124654e-324", 4.9406564584124654e-324); // minimum denormal
@@ -246,7 +244,6 @@ static void TestParseDouble() {
     TEST_DOUBLE(fullPrecision, "1e-214748364", 0.0);
     TEST_DOUBLE(fullPrecision, "1e-21474836311", 0.0);
     TEST_DOUBLE(fullPrecision, "0.017976931348623157e+310", 1.7976931348623157e+308); // Max double in another form
-    TEST_DOUBLE(fullPrecision, "128.74836467836484838364836483643636483648e-336", 0.0); // Issue #1251
 
     // Since
     // abs((2^-1022 - 2^-1074) - 2.2250738585072012e-308) = 3.109754131239141401123495768877590405345064751974375599... x 10^-324


### PR DESCRIPTION
Reverts StilesCrisis/rapidjson#6
This pull request needs to be split into two parts